### PR TITLE
Insert newline at the end of files

### DIFF
--- a/downloads-counter.php
+++ b/downloads-counter.php
@@ -48,7 +48,7 @@ class DownloadsCounterPlugin extends Plugin
         $fullFileName = $dir. DS . $filename;
 
         $file = File::instance($fullFileName);
-        $last_download = "\nlast download: ".date('d/m/Y H:i:s');
+        $last_download = "\nlast download: " . date('d/m/Y H:i:s') . "\n";
 
         // If file was downloaded previously, update last download and increase the counter
         if ($file->exists()) {


### PR DESCRIPTION
When using a for loop to see all of the download stats for files (such as `for FILE in *.txt; do echo $FILE; cat "$FILE"; done` in bash), not having a newline at the end of the file made it difficult to read.

For example:
```
File1.mp3.txt
number of times: 2
last download: 04/04/2025 15:32:53File2.mp3.txt
number of times: 2
last download: 14/10/2024 21:19:55File3.mp3.txt
number of times: 1
last download: 25/04/2025 21:35:25
```

With newlines at the end of the files, the output will look like this:
```
File4.mp3.txt
number of times: 1
last download: 10/05/2025 03:54:04
File5.mp3.txt
number of times: 1
last download: 10/05/2025 03:53:50
```